### PR TITLE
Add gitignore to avoid runtime files getting added to Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-.pyc
+*.pyc
+*.db
 config.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.pyc
+config.txt


### PR DESCRIPTION
Just a small gitignore file which avoids installation-specific config and .pyc files from being shown as a difference in the git working directory.

(When deployed from a clone of the git repo, being able to fast-forward to get latest updates without installation-specific state, e.g. the config.txt file, showing up as changes is useful.)
