### PR TITLE
Make telemetry optional

### DIFF
--- a/config-agwpe.txt
+++ b/config-agwpe.txt
@@ -117,6 +117,10 @@ host=<host>
 # @ is replaced with station position
 #FILTER=<str>
 
+# Whether to send telemetry every 15 minutes to the ISGW
+# Enabled by default
+#SENDTELEMETRY=<y/n>
+
 #################################################################
 #                                                               #
 # WRB server settings; remove this section to disable it        #

--- a/config-ax25.txt
+++ b/config-ax25.txt
@@ -118,6 +118,10 @@ host=<host>
 # @ is replaced with station position
 #FILTER=<str>
 
+# Whether to send telemetry every 15 minutes to the ISGW
+# Enabled by default
+#SENDTELEMETRY=<y/n>
+
 #################################################################
 #                                                               #
 # WRB server settings; remove this section to disable it        #

--- a/config-kiss.txt
+++ b/config-kiss.txt
@@ -118,6 +118,10 @@ host=<host>
 # @ is replaced with station position
 #FILTER=<str>
 
+# Whether to send telemetry every 15 minutes to the ISGW
+# Enabled by default
+#SENDTELEMETRY=<y/n>
+
 #################################################################
 #                                                               #
 # WRB server settings; remove this section to disable it        #

--- a/dixprs.py
+++ b/dixprs.py
@@ -306,6 +306,12 @@ if __name__ == '__main__':
             cvars.put('igwCFGbtxt', p)
         except KeyError:
             cvars.put('igwCFGbtxt', genCFGbcntxt)
+
+        try:
+            p = sect['SENDTELEMETRY']
+            cvars.put('igwCFGsendtelem', dixprscfg.yesno(p)
+        except KeyError:
+            cvars.put('igwCFGsendtelem', True)
             
     #------------------------------------------------   
     # WEB server configuration settings
@@ -1392,7 +1398,7 @@ if __name__ == '__main__':
                 dixlibsql.DbTmpPurge()
 
                 # Send telemetry to ISGW if enabled
-                if pigate <> None:
+                if pigate <> None and cvars.get('igwCFGsendtelem')
                     for port in range(0, len(radioports)):
                         tlmw = dixlibsql.GetTlmData(port)
                         tlmu = ':%-9s:UNIT.pkt/15m,pkt/15m,stn/15m,stn/15m,pkt/15m' % (cvars.get('genCFGcall'))

--- a/dixprs.py
+++ b/dixprs.py
@@ -309,7 +309,7 @@ if __name__ == '__main__':
 
         try:
             p = sect['SENDTELEMETRY']
-            cvars.put('igwCFGsendtelem', dixprscfg.yesno(p)
+            cvars.put('igwCFGsendtelem', dixprscfg.yesno(p))
         except KeyError:
             cvars.put('igwCFGsendtelem', True)
             
@@ -1398,7 +1398,7 @@ if __name__ == '__main__':
                 dixlibsql.DbTmpPurge()
 
                 # Send telemetry to ISGW if enabled
-                if pigate <> None and cvars.get('igwCFGsendtelem')
+                if pigate <> None and cvars.get('igwCFGsendtelem'):
                     for port in range(0, len(radioports)):
                         tlmw = dixlibsql.GetTlmData(port)
                         tlmu = ':%-9s:UNIT.pkt/15m,pkt/15m,stn/15m,stn/15m,pkt/15m' % (cvars.get('genCFGcall'))


### PR DESCRIPTION
This adds a new setting, `SENDTELEMETRY`, which allows the internal telemetry beacons to be disabled, for example if telemetry is being used for another purpose via the spool directory.